### PR TITLE
Tentative fix for linking to the CoreFoundation framework on OSX.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 8100085dada279bf3ee00cd064d43b5f55e5d913be0dfe2906f06f8f28d5b37e
   patches:
     - clang4_osx_fix.diff  # [osx]
+    - osx_framework_fix.diff  # [osx]
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win and vc<14]
 
 requirements:

--- a/recipe/osx_framework_fix.diff
+++ b/recipe/osx_framework_fix.diff
@@ -1,0 +1,13 @@
+diff --git a/absl/time/CMakeLists.txt b/absl/time/CMakeLists.txt
+index 5909832..9fa49f7 100644
+--- a/absl/time/CMakeLists.txt
++++ b/absl/time/CMakeLists.txt
+@@ -83,7 +83,7 @@ absl_cc_library(
+   COPTS
+     ${ABSL_DEFAULT_COPTS}
+   DEPS
+-    $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>
++    $<$<PLATFORM_ID:Darwin>:"-framework CoreFoundation">
+ )
+ 
+ absl_cc_library(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
