### PR TITLE
backport patch for ABSL_CONSUME_DLL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,11 @@ source:
     # backport of https://github.com/abseil/abseil-cpp/pull/1115 (two commits)
     - patches/0005-alphabetize-ABSL_INTERNAL_DLL_TARGETS.patch
     - patches/0006-avoid-building-static-libs-on-windows-when-BUILD_SHA.patch
+    # backport https://github.com/abseil/abseil-cpp/pull/1269
+    - patches/0007-Compile-all-dependencies-of-the-DLL-with-ABSL_CONSUM.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   {% if shared_libs == "ON" %}

--- a/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
+++ b/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
@@ -1,7 +1,7 @@
 From 336f3e70a058f6b07aa25725ea2a23a739f190ef Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 15:05:46 +0200
-Subject: [PATCH 1/6] patch out the build issue on clang4 osx
+Subject: [PATCH 1/7] patch out the build issue on clang4 osx
 
 ---
  absl/time/internal/cctz/include/cctz/civil_time_detail.h | 4 ++++
@@ -23,5 +23,5 @@ index a5b084e6..0a9a4389 100644
  #include <limits>
  #include <ostream>
 -- 
-2.37.0.windows.1
+2.37.3.windows.1
 

--- a/recipe/patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
+++ b/recipe/patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
@@ -1,7 +1,7 @@
 From a99ff2d64fb489dfc207572edb2d8a151d3c92f9 Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 21:39:26 +0200
-Subject: [PATCH 2/6] fix for linking to the CoreFoundation framework on OSX
+Subject: [PATCH 2/7] fix for linking to the CoreFoundation framework on OSX
 
 ---
  absl/time/CMakeLists.txt | 6 ++++--
@@ -27,5 +27,5 @@ index debab3ba..4eb9ebf8 100644
  absl_cc_library(
    NAME
 -- 
-2.37.0.windows.1
+2.37.3.windows.1
 

--- a/recipe/patches/0003-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
+++ b/recipe/patches/0003-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
@@ -1,7 +1,7 @@
 From 1a77917fe7c5c3feece1a608d5537f848f4e930f Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Thu, 30 Jul 2020 13:01:32 +0200
-Subject: [PATCH 3/6] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
+Subject: [PATCH 3/7] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
 
 see also https://github.com/microsoft/vcpkg/issues/13945
 ---
@@ -41,5 +41,5 @@ index 0d6c1ec3..8df92751 100644
      # Standard). These flags are used for detecting whether or not the target
      # architecture has hardware support for AES instructions which can be used
 -- 
-2.37.0.windows.1
+2.37.3.windows.1
 

--- a/recipe/patches/0004-add-missing-osx-workaround.patch
+++ b/recipe/patches/0004-add-missing-osx-workaround.patch
@@ -1,7 +1,7 @@
 From 3b5f3943a593d5c7544b594d0bd6eec569d26067 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Fri, 1 Jul 2022 13:37:17 +0200
-Subject: [PATCH 4/6] add missing osx workaround
+Subject: [PATCH 4/7] add missing osx workaround
 
 ---
  absl/debugging/internal/examine_stack.cc | 4 ++++
@@ -23,5 +23,5 @@ index 5bdd341e..e86f384f 100644
  #include <sys/ucontext.h>
  #endif
 -- 
-2.37.0.windows.1
+2.37.3.windows.1
 

--- a/recipe/patches/0005-alphabetize-ABSL_INTERNAL_DLL_TARGETS.patch
+++ b/recipe/patches/0005-alphabetize-ABSL_INTERNAL_DLL_TARGETS.patch
@@ -1,7 +1,7 @@
 From fa9d0f4abb4c4a3112e2c1faa3138206354bd6c4 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 2 Mar 2022 08:07:20 +1100
-Subject: [PATCH 5/6] alphabetize ABSL_INTERNAL_DLL_TARGETS
+Subject: [PATCH 5/7] alphabetize ABSL_INTERNAL_DLL_TARGETS
 
 this is a pure reshuffle; no additions/deletions
 ---
@@ -220,5 +220,5 @@ index 00cddb84..5638ed66 100644
  
  function(absl_internal_dll_contains)
 -- 
-2.37.0.windows.1
+2.37.3.windows.1
 

--- a/recipe/patches/0006-avoid-building-static-libs-on-windows-when-BUILD_SHA.patch
+++ b/recipe/patches/0006-avoid-building-static-libs-on-windows-when-BUILD_SHA.patch
@@ -1,7 +1,7 @@
 From 5b0225562085b17749a04a57cd6e89e8926c7053 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 2 Mar 2022 13:43:37 +1100
-Subject: [PATCH 6/6] avoid building static libs on windows when
+Subject: [PATCH 6/7] avoid building static libs on windows when
  BUILD_SHARED_LIBS=ON
 
 except all flags_* libraries, for which DLL builds on windows
@@ -57,5 +57,5 @@ index 5638ed66..b9a3664b 100644
    "str_format_internal"
    "strings"
 -- 
-2.37.0.windows.1
+2.37.3.windows.1
 

--- a/recipe/patches/0007-Compile-all-dependencies-of-the-DLL-with-ABSL_CONSUM.patch
+++ b/recipe/patches/0007-Compile-all-dependencies-of-the-DLL-with-ABSL_CONSUM.patch
@@ -1,0 +1,24 @@
+From d4b55614c1f10515c7a8a98ec24fe5a1df5750d2 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Fri, 2 Sep 2022 04:04:37 -0500
+Subject: [PATCH 7/7] Compile all dependencies of the DLL with ABSL_CONSUME_DLL
+
+---
+ CMake/AbseilDll.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
+index b9a3664b..5e1316f0 100644
+--- a/CMake/AbseilDll.cmake
++++ b/CMake/AbseilDll.cmake
+@@ -555,6 +555,7 @@ function(absl_make_dll)
+       NOMINMAX
+     INTERFACE
+       ${ABSL_CC_LIB_DEFINES}
++      ABSL_CONSUME_DLL
+   )
+   install(TARGETS abseil_dll EXPORT ${PROJECT_NAME}Targets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-- 
+2.37.3.windows.1
+


### PR DESCRIPTION
Backport https://github.com/abseil/abseil-cpp/pull/1269 to verify this fixes some of the issues we're seeing in the migration. Thanks @isuruf!