### PR TITLE
Add patch for windows downstream users

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,11 @@ source:
     - patches/0006-avoid-building-static-libs-on-windows-when-BUILD_SHA.patch
     # backport https://github.com/abseil/abseil-cpp/pull/1269
     - patches/0007-Compile-all-dependencies-of-the-DLL-with-ABSL_CONSUM.patch
+{% if shared_libs == "ON" %}
     # Helps downstream packages import the dll without an extra defin
     # https://github.com/conda-forge/abseil-cpp-feedstock/issues/43#issuecomment-1242969515
     - patches/0008-default_dll_import_for_windows.patch
+{% endif %}
 
 build:
   number: 4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,12 @@ source:
     - patches/0006-avoid-building-static-libs-on-windows-when-BUILD_SHA.patch
     # backport https://github.com/abseil/abseil-cpp/pull/1269
     - patches/0007-Compile-all-dependencies-of-the-DLL-with-ABSL_CONSUM.patch
+    # Helps downstream packages import the dll without an extra defin
+    # https://github.com/conda-forge/abseil-cpp-feedstock/issues/43#issuecomment-1242969515
+    - patches/0008-default_dll_import_for_windows.patch
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   {% if shared_libs == "ON" %}

--- a/recipe/patches/0008-default_dll_import_for_windows.patch
+++ b/recipe/patches/0008-default_dll_import_for_windows.patch
@@ -1,0 +1,15 @@
+--- absl/base/config.h	2022-06-23 14:22:47.000000000 -0400
++++ absl/base/config.h.b	2022-09-11 10:28:16.033334900 -0400
+@@ -737,10 +737,9 @@
+ #if defined(_MSC_VER)
+ #if defined(ABSL_BUILD_DLL)
+ #define ABSL_DLL __declspec(dllexport)
+-#elif defined(ABSL_CONSUME_DLL)
+-#define ABSL_DLL __declspec(dllimport)
+ #else
+-#define ABSL_DLL
++// conda-forge addition: by default, users import the definitions defined here
++#define ABSL_DLL __declspec(dllimport)
+ #endif
+ #else
+ #define ABSL_DLL


### PR DESCRIPTION
@h-vetinari does this need a condition for static/shared?

I typically don't like to condition the patches on the operating system, but this patch should only affect windows users.

See source: https://github.com/abseil/abseil-cpp/blob/lts_2022_06_23/absl/base/config.h#L741
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
