### PR TITLE
build test targets; bump to v20230125.2

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
       win_64_:
@@ -36,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,9 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About abseil-cpp
-================
+About abseil-cpp-feedstock
+==========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/abseil-cpp-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/abseil/abseil-cpp
 
 Package license: Apache-2.0
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/abseil-cpp-feedstock/blob/main/LICENSE.txt)
 
 Summary: Abseil Common Libraries (C++)
 
@@ -90,6 +90,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libabseil-green.svg)](https://anaconda.org/conda-forge/libabseil) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libabseil.svg)](https://anaconda.org/conda-forge/libabseil) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libabseil.svg)](https://anaconda.org/conda-forge/libabseil) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libabseil.svg)](https://anaconda.org/conda-forge/libabseil) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libabseil--tests-green.svg)](https://anaconda.org/conda-forge/libabseil-tests) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libabseil-tests.svg)](https://anaconda.org/conda-forge/libabseil-tests) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libabseil-tests.svg)](https://anaconda.org/conda-forge/libabseil-tests) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libabseil-tests.svg)](https://anaconda.org/conda-forge/libabseil-tests) |
 
 Installing abseil-cpp
 =====================
@@ -101,16 +102,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libabseil` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libabseil, libabseil-tests` can be installed with `conda`:
 
 ```
-conda install libabseil
+conda install libabseil libabseil-tests
 ```
 
 or with `mamba`:
 
 ```
-mamba install libabseil
+mamba install libabseil libabseil-tests
 ```
 
 It is possible to list all of the versions of `libabseil` available on your platform with `conda`:

--- a/recipe/build-abseil.bat
+++ b/recipe/build-abseil.bat
@@ -1,7 +1,15 @@
 @echo on
 
+SetLocal EnableDelayedExpansion
+
 mkdir build
 cd build
+
+if [%PKG_NAME%] == [libabseil-tests] (
+    set "EXTRA_ARGS=-DBUILD_TESTING=ON -DABSL_BUILD_TEST_HELPERS=ON -DABSL_BUILD_TESTING=ON"
+    set "EXTRA_ARGS=!EXTRA_ARGS! -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON"
+)
+
 cmake -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_CXX_STANDARD=17 ^
@@ -9,6 +17,7 @@ cmake -GNinja ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -DBUILD_SHARED_LIBS=ON ^
     -DABSL_PROPAGATE_CXX_STD=ON ^
+    !EXTRA_ARGS! ^
     ..
 if %ERRORLEVEL% neq 0 exit 1
 

--- a/recipe/build-abseil.sh
+++ b/recipe/build-abseil.sh
@@ -13,6 +13,12 @@ fi
 if [[ "$PKG_NAME" == "libabseil-tests" ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_TESTING=ON -DABSL_BUILD_TESTING=ON"
     CMAKE_ARGS="${CMAKE_ARGS} -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON"
+    if [[ "${target_platform}" == osx-* ]]; then
+        # test targets require C11's aligned_alloc, which doesn't compile even
+        # with a newer MACOSX_SDK_VERSION; need to bump target version too
+        CMAKE_ARGS="$(echo $CMAKE_ARGS | sed 's/-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 //g')"
+        CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
+    fi
 fi
 
 cmake -G Ninja \

--- a/recipe/build-abseil.sh
+++ b/recipe/build-abseil.sh
@@ -10,14 +10,19 @@ if [[ "${target_platform}" == osx-* ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
-cmake ${CMAKE_ARGS} \
+if [[ "$PKG_NAME" == "libabseil-tests" ]]; then
+    CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_TESTING=ON -DABSL_BUILD_TESTING=ON"
+    CMAKE_ARGS="${CMAKE_ARGS} -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON"
+fi
+
+cmake -G Ninja \
+    ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_STANDARD=17 \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DBUILD_SHARED_LIBS=ON \
     -DABSL_PROPAGATE_CXX_STD=ON \
-    -GNinja \
     ..
 
 cmake --build .

--- a/recipe/build-abseil.sh
+++ b/recipe/build-abseil.sh
@@ -5,6 +5,11 @@ set -exuo pipefail
 mkdir -p build
 cd build
 
+if [[ "${target_platform}" == osx-* ]]; then
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 cmake ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_STANDARD=17 \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "10.13"                # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ source:
     # https://github.com/conda-forge/abseil-cpp-feedstock/issues/43#issuecomment-1242969515
     - patches/0006-default-dll-import-for-windows.patch  # [win]
     - patches/0007-Fix-ABSL_PROPAGATE_CXX_STD-cmake-option.patch
+    # backport https://github.com/abseil/abseil-cpp/commit/807763a7f57dcf0ba4af7c3b218013e8f525e811
+    # to be able to install TESTONLY libraries
+    - patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@
     "scoped_set_env", "spinlock_wait", "stacktrace", "status", "statusor", "strerror", "strings",
     "symbolize", "synchronization", "time", "time_zone"
 ] %}
+# test helper targets (but used e.g. by protobuf)
+{% set absl_test_libs = ["scoped_mock_log"] %}
 
 package:
   name: abseil-split
@@ -79,6 +81,9 @@ outputs:
         # windows-only (almost-)all-in-one DLL + import library
         - if not exist %LIBRARY_BIN%\\abseil_dll.dll exit 1           # [win]
         - if not exist %LIBRARY_LIB%\\abseil_dll.lib exit 1           # [win]
+        # absence of test targets in regular abseil output
+        - if exist %LIBRARY_BIN%\\abseil_test_dll.dll exit 1          # [win]
+        - if exist %LIBRARY_LIB%\\abseil_test_dll.lib exit 1          # [win]
 
         # absl_* libraries
       {% for each_lib in absl_libs %}
@@ -98,6 +103,14 @@ outputs:
         - pkg-config --print-errors --exact-version "{{ v_major }}" absl_{{ each_lib }}
       {% endfor %}
 
+        # absence of test targets in regular abseil output
+      {% for each_lib in absl_test_libs %}
+        # absence of all libs
+        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}${SHLIB_EXT}    # [unix]
+        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}.a              # [unix]
+        - if exist %LIBRARY_LIB%\\absl_{{ each_lib }}.lib exit 1      # [win]
+      {% endfor %}
+
         # pkg-config (abseil_dll)
         - pkg-config --print-errors --exact-version "{{ v_major }}" abseil_dll  # [win]
 
@@ -110,6 +123,48 @@ outputs:
         - cmake --build .
         - ./flags_example    # [unix]
         - flags_example.exe  # [win]
+
+  # tests & test-helpers
+  - name: libabseil-tests
+    script: build-abseil.sh   # [unix]
+    script: build-abseil.bat  # [win]
+    build:
+      string: cxx{{ cxx_standard }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - gtest
+        - {{ pin_subpackage("libabseil", exact=True) }}
+      run:
+        - gtest
+        - {{ pin_subpackage("libabseil", exact=True) }}
+
+    test:
+      requires:
+        - pkg-config
+      commands:
+        # windows-only (almost-)all-in-one DLL + import library
+        - if not exist %LIBRARY_BIN%\\abseil_test_dll.dll exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\\abseil_test_dll.lib exit 1      # [win]
+
+        # absl_* libraries
+      {% for each_lib in absl_test_libs %}
+        # presence of shared libs
+        - test -f $PREFIX/lib/libabsl_{{ each_lib }}${SHLIB_EXT}      # [unix]
+        # absence of static libs
+        - test ! -f $PREFIX/lib/libabsl_{{ each_lib }}.a              # [unix]
+
+        # pkg-config (should point to abseil_test_dll on shared windows builds)
+        - pkg-config --print-errors --exact-version "{{ v_major }}" absl_{{ each_lib }}
+      {% endfor %}
+
+        # pkg-config abseil_test_dll
+        - pkg-config --print-errors --exact-version "{{ v_major }}" abseil_test_dll  # [win]
 
 about:
   home: https://github.com/abseil/abseil-cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20230125.0" %}
+{% set version = "20230125.2" %}
 {% set v_major = version.split(".")[0] %}
 # needs to match across all dependent packages; using C++20
 # is potentially problematic in some cases, see #45
@@ -28,7 +28,7 @@ package:
 
 source:
   url: https://github.com/abseil/abseil-cpp/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21
+  sha256: 9a2b5752d7bfade0bdeee2701de17c9480620f8b237e1964c1b9967c75374906
   patches:
     - patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
     - patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
@@ -45,7 +45,7 @@ source:
     - patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   # default behaviour is shared; however note that upstream does not support

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,6 +147,9 @@ outputs:
       run:
         - gtest
         - {{ pin_subpackage("libabseil", exact=True) }}
+      run_constrained:
+        # only for libabseil-tests, see build-abseil.sh
+        - __osx >=10.13  # [osx and x86_64]
 
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ source:
     # backport https://github.com/abseil/abseil-cpp/commit/807763a7f57dcf0ba4af7c3b218013e8f525e811
     # to be able to install TESTONLY libraries
     - patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
+    # backport abseil/abseil-cpp#1445 for shared builds including test targets on win
     - patches/0009-add-some-necessary-source-files-to-ABSL_INTERNAL_TES.patch
     - patches/0010-update-ABSL_CC_TEST_LINKOPTS-when-using-shared-build.patch
     - patches/0011-make-CordzHandle-and-relevant-internal-state-use-ABS.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,9 @@ source:
     # backport https://github.com/abseil/abseil-cpp/commit/807763a7f57dcf0ba4af7c3b218013e8f525e811
     # to be able to install TESTONLY libraries
     - patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
+    - patches/0009-add-some-necessary-source-files-to-ABSL_INTERNAL_TES.patch
+    - patches/0010-update-ABSL_CC_TEST_LINKOPTS-when-using-shared-build.patch
+    - patches/0011-make-CordzHandle-and-relevant-internal-state-use-ABS.patch
 
 build:
   number: 0

--- a/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
+++ b/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
@@ -1,7 +1,7 @@
 From d59eb9046823f39006350a508e30bac815b63383 Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 15:05:46 +0200
-Subject: [PATCH 1/8] patch out the build issue on clang4 osx
+Subject: [PATCH 01/11] patch out the build issue on clang4 osx
 
 ---
  absl/time/internal/cctz/include/cctz/civil_time_detail.h | 4 ++++
@@ -22,6 +22,3 @@ index a5b084e6..0a9a4389 100644
  #include <cstdint>
  #include <limits>
  #include <ostream>
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
+++ b/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
@@ -1,7 +1,7 @@
 From d59eb9046823f39006350a508e30bac815b63383 Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 15:05:46 +0200
-Subject: [PATCH 1/7] patch out the build issue on clang4 osx
+Subject: [PATCH 1/8] patch out the build issue on clang4 osx
 
 ---
  absl/time/internal/cctz/include/cctz/civil_time_detail.h | 4 ++++
@@ -23,5 +23,5 @@ index a5b084e6..0a9a4389 100644
  #include <limits>
  #include <ostream>
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
+++ b/recipe/patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
@@ -1,7 +1,7 @@
 From c8bd75a96ecb2bd528399829692307a03985da0b Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 21:39:26 +0200
-Subject: [PATCH 2/7] fix for linking to the CoreFoundation framework on OSX
+Subject: [PATCH 2/8] fix for linking to the CoreFoundation framework on OSX
 
 ---
  absl/time/CMakeLists.txt | 6 ++++--
@@ -27,5 +27,5 @@ index 7b720540..cfed46a4 100644
  absl_cc_library(
    NAME
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
+++ b/recipe/patches/0002-fix-for-linking-to-the-CoreFoundation-framework-on-O.patch
@@ -1,7 +1,7 @@
 From c8bd75a96ecb2bd528399829692307a03985da0b Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 21:39:26 +0200
-Subject: [PATCH 2/8] fix for linking to the CoreFoundation framework on OSX
+Subject: [PATCH 02/11] fix for linking to the CoreFoundation framework on OSX
 
 ---
  absl/time/CMakeLists.txt | 6 ++++--
@@ -26,6 +26,3 @@ index 7b720540..cfed46a4 100644
  # Internal-only target, do not depend on directly.
  absl_cc_library(
    NAME
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0003-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
+++ b/recipe/patches/0003-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
@@ -1,7 +1,7 @@
 From dfbac02988c119967037c53a0f78f03bdf01e1c8 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Thu, 30 Jul 2020 13:01:32 +0200
-Subject: [PATCH 3/7] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
+Subject: [PATCH 3/8] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
 
 see also https://github.com/microsoft/vcpkg/issues/13945
 ---
@@ -41,5 +41,5 @@ index e6e11949..09ac7618 100644
      # Standard). These flags are used for detecting whether or not the target
      # architecture has hardware support for AES instructions which can be used
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0003-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
+++ b/recipe/patches/0003-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
@@ -1,7 +1,7 @@
 From dfbac02988c119967037c53a0f78f03bdf01e1c8 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Thu, 30 Jul 2020 13:01:32 +0200
-Subject: [PATCH 3/8] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
+Subject: [PATCH 03/11] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
 
 see also https://github.com/microsoft/vcpkg/issues/13945
 ---
@@ -40,6 +40,3 @@ index e6e11949..09ac7618 100644
      # "HWAES" is an abbreviation for "hardware AES" (AES - Advanced Encryption
      # Standard). These flags are used for detecting whether or not the target
      # architecture has hardware support for AES instructions which can be used
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0004-add-missing-osx-workaround.patch
+++ b/recipe/patches/0004-add-missing-osx-workaround.patch
@@ -1,7 +1,7 @@
 From b6c0b4ffa8aa2ed4146e2c9ca9b0406e2da4f1d3 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Fri, 1 Jul 2022 13:37:17 +0200
-Subject: [PATCH 4/8] add missing osx workaround
+Subject: [PATCH 04/11] add missing osx workaround
 
 ---
  absl/debugging/internal/examine_stack.cc | 4 ++++
@@ -22,6 +22,3 @@ index 57863228..91862aed 100644
  #if defined(__linux__) || defined(__APPLE__)
  #include <sys/ucontext.h>
  #endif
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0004-add-missing-osx-workaround.patch
+++ b/recipe/patches/0004-add-missing-osx-workaround.patch
@@ -1,7 +1,7 @@
 From b6c0b4ffa8aa2ed4146e2c9ca9b0406e2da4f1d3 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Fri, 1 Jul 2022 13:37:17 +0200
-Subject: [PATCH 4/7] add missing osx workaround
+Subject: [PATCH 4/8] add missing osx workaround
 
 ---
  absl/debugging/internal/examine_stack.cc | 4 ++++
@@ -23,5 +23,5 @@ index 57863228..91862aed 100644
  #include <sys/ucontext.h>
  #endif
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0005-fix-some-missing-ABSL_INTERNAL_DLL_TARGETS-for-share.patch
+++ b/recipe/patches/0005-fix-some-missing-ABSL_INTERNAL_DLL_TARGETS-for-share.patch
@@ -1,7 +1,7 @@
 From d6480ef5044ab0cb548dcae070327481a9da46c9 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 7 Feb 2023 13:01:27 +1100
-Subject: [PATCH 5/8] fix some missing ABSL_INTERNAL_DLL_TARGETS for shared
+Subject: [PATCH 05/11] fix some missing ABSL_INTERNAL_DLL_TARGETS for shared
  builds
 
 ---
@@ -54,6 +54,3 @@ index c4a41e6d..c4c92359 100644
    "random_internal_mock_overload_set"
    "scoped_mock_log"
  )
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0005-fix-some-missing-ABSL_INTERNAL_DLL_TARGETS-for-share.patch
+++ b/recipe/patches/0005-fix-some-missing-ABSL_INTERNAL_DLL_TARGETS-for-share.patch
@@ -1,15 +1,15 @@
-From 54b57e1ccc6f2a9786f240a376d33eaf34daf3d2 Mon Sep 17 00:00:00 2001
+From d6480ef5044ab0cb548dcae070327481a9da46c9 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 7 Feb 2023 13:01:27 +1100
-Subject: [PATCH 5/7] fix some missing ABSL_INTERNAL_DLL_TARGETS for shared
+Subject: [PATCH 5/8] fix some missing ABSL_INTERNAL_DLL_TARGETS for shared
  builds
 
 ---
- CMake/AbseilDll.cmake | 11 +++++++++++
- 1 file changed, 11 insertions(+)
+ CMake/AbseilDll.cmake | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
-index c4a41e6d..eec6dd99 100644
+index c4a41e6d..c4c92359 100644
 --- a/CMake/AbseilDll.cmake
 +++ b/CMake/AbseilDll.cmake
 @@ -448,8 +448,14 @@ set(ABSL_INTERNAL_DLL_TARGETS
@@ -27,14 +27,7 @@ index c4a41e6d..eec6dd99 100644
    "crc_cpu_detect"
    "crc_internal"
    "crc32c"
-@@ -498,12 +504,14 @@ set(ABSL_INTERNAL_DLL_TARGETS
-   "log_initialize"
-   "log"
-   "log_entry"
-+  "log_flags"
-   "log_sink"
-   "log_sink_registry"
-   "log_streamer"
+@@ -504,6 +510,7 @@ set(ABSL_INTERNAL_DLL_TARGETS
    "log_internal_structured"
    "log_severity"
    "log_structured"
@@ -42,7 +35,7 @@ index c4a41e6d..eec6dd99 100644
    "malloc_internal"
    "memory"
    "meta"
-@@ -555,8 +563,10 @@ set(ABSL_INTERNAL_DLL_TARGETS
+@@ -555,8 +562,10 @@ set(ABSL_INTERNAL_DLL_TARGETS
    "stack_consumption"
    "stacktrace"
    "status"
@@ -53,7 +46,7 @@ index c4a41e6d..eec6dd99 100644
    "strings"
    "strings_internal"
    "symbolize"
-@@ -588,6 +598,7 @@ set(ABSL_INTERNAL_TEST_DLL_TARGETS
+@@ -588,6 +597,7 @@ set(ABSL_INTERNAL_TEST_DLL_TARGETS
    "cordz_test_helpers"
    "hash_testing"
    "random_mocking_bit_gen"
@@ -62,5 +55,5 @@ index c4a41e6d..eec6dd99 100644
    "scoped_mock_log"
  )
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0006-default-dll-import-for-windows.patch
+++ b/recipe/patches/0006-default-dll-import-for-windows.patch
@@ -1,7 +1,7 @@
-From 08797647a52610ac2437c4d1b0c3af38d2704fd4 Mon Sep 17 00:00:00 2001
+From d062fa3db9557ec227a40af6c40727249499022f Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 11 Sep 2022 10:32:19 -0400
-Subject: [PATCH 6/7] default dll import for windows
+Subject: [PATCH 6/8] default dll import for windows
 
 ---
  absl/base/config.h | 5 ++---
@@ -25,5 +25,5 @@ index e35d2e48..391da4de 100644
  #else
  #define ABSL_DLL
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0006-default-dll-import-for-windows.patch
+++ b/recipe/patches/0006-default-dll-import-for-windows.patch
@@ -1,7 +1,7 @@
 From d062fa3db9557ec227a40af6c40727249499022f Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 11 Sep 2022 10:32:19 -0400
-Subject: [PATCH 6/8] default dll import for windows
+Subject: [PATCH 06/11] default dll import for windows
 
 ---
  absl/base/config.h | 5 ++---
@@ -24,6 +24,3 @@ index e35d2e48..391da4de 100644
  #endif
  #else
  #define ABSL_DLL
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0007-Fix-ABSL_PROPAGATE_CXX_STD-cmake-option.patch
+++ b/recipe/patches/0007-Fix-ABSL_PROPAGATE_CXX_STD-cmake-option.patch
@@ -1,17 +1,17 @@
-From 6401d1329e43ed76f9dc39baa2f7c08adca7693e Mon Sep 17 00:00:00 2001
+From dd56821ac6927441e33387072b8dc3c3569644a4 Mon Sep 17 00:00:00 2001
 From: Silvio Traversaro <silvio@traversaro.it>
 Date: Wed, 15 Feb 2023 15:55:54 +0100
-Subject: [PATCH 7/7] Fix ABSL_PROPAGATE_CXX_STD cmake option
+Subject: [PATCH 7/8] Fix ABSL_PROPAGATE_CXX_STD cmake option
 
 ---
  CMake/AbseilDll.cmake | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
-index eec6dd99..4ed03276 100644
+index c4c92359..1aecd926 100644
 --- a/CMake/AbseilDll.cmake
 +++ b/CMake/AbseilDll.cmake
-@@ -798,7 +798,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
+@@ -797,7 +797,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
      # Abseil libraries require C++14 as the current minimum standard. When
      # compiled with C++17 (either because it is the compiler's default or
      # explicitly requested), then Abseil requires C++17.
@@ -20,7 +20,7 @@ index eec6dd99..4ed03276 100644
    else()
      # Note: This is legacy (before CMake 3.8) behavior. Setting the
      # target-level CXX_STANDARD property to ABSL_CXX_STANDARD (which is
-@@ -808,8 +808,8 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
+@@ -807,8 +807,8 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
      # CXX_STANDARD_REQUIRED does guard against the top-level CMake project
      # not having enabled CMAKE_CXX_STANDARD_REQUIRED (which prevents
      # "decaying" to an older standard if the requested one isn't available).
@@ -32,5 +32,5 @@ index eec6dd99..4ed03276 100644
  
    install(TARGETS ${_dll} EXPORT ${PROJECT_NAME}Targets
 -- 
-2.33.0.windows.2
+2.38.1.windows.1
 

--- a/recipe/patches/0007-Fix-ABSL_PROPAGATE_CXX_STD-cmake-option.patch
+++ b/recipe/patches/0007-Fix-ABSL_PROPAGATE_CXX_STD-cmake-option.patch
@@ -1,7 +1,7 @@
 From dd56821ac6927441e33387072b8dc3c3569644a4 Mon Sep 17 00:00:00 2001
 From: Silvio Traversaro <silvio@traversaro.it>
 Date: Wed, 15 Feb 2023 15:55:54 +0100
-Subject: [PATCH 7/8] Fix ABSL_PROPAGATE_CXX_STD cmake option
+Subject: [PATCH 07/11] Fix ABSL_PROPAGATE_CXX_STD cmake option
 
 ---
  CMake/AbseilDll.cmake | 6 +++---
@@ -31,6 +31,3 @@ index c4c92359..1aecd926 100644
    endif()
  
    install(TARGETS ${_dll} EXPORT ${PROJECT_NAME}Targets
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
+++ b/recipe/patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
@@ -1,0 +1,141 @@
+From 4ed51580e60f87f0cdd2024b407aa6688f65c5ef Mon Sep 17 00:00:00 2001
+From: Derek Mauro <dmauro@google.com>
+Date: Thu, 2 Mar 2023 17:32:02 -0800
+Subject: [PATCH 8/8] CMake: Install TESTONLY libraries and their dependencies
+ when they are built
+
+https://github.com/abseil/abseil-cpp/issues/1407
+
+PiperOrigin-RevId: 513684529
+Change-Id: Ie0a164eea32becfef8f8e4a112aee158fd93dd7e
+---
+ CMake/AbseilHelpers.cmake | 92 +++++++++++++++++++--------------------
+ 1 file changed, 44 insertions(+), 48 deletions(-)
+
+diff --git a/CMake/AbseilHelpers.cmake b/CMake/AbseilHelpers.cmake
+index 6d059e7e..f452a676 100644
+--- a/CMake/AbseilHelpers.cmake
++++ b/CMake/AbseilHelpers.cmake
+@@ -153,55 +153,54 @@ function(absl_cc_library)
+ 
+   # Generate a pkg-config file for every library:
+   if(ABSL_ENABLE_INSTALL)
+-    if(NOT ABSL_CC_LIB_TESTONLY)
+-      if(absl_VERSION)
+-        set(PC_VERSION "${absl_VERSION}")
+-      else()
+-        set(PC_VERSION "head")
+-      endif()
+-      if(NOT _build_type STREQUAL "dll")
+-        set(LNK_LIB "${LNK_LIB} -labsl_${_NAME}")
+-      endif()
+-      foreach(dep ${ABSL_CC_LIB_DEPS})
+-        if(${dep} MATCHES "^absl::(.*)")
+-          # for DLL builds many libs are not created, but add
+-          # the pkgconfigs nevertheless, pointing to the dll.
+-          if(_build_type STREQUAL "dll")
+-            # hide this MATCHES in an if-clause so it doesn't overwrite
+-            # the CMAKE_MATCH_1 from (${dep} MATCHES "^absl::(.*)")
+-            if(NOT PC_DEPS MATCHES "abseil_dll")
+-              # Join deps with commas.
+-              if(PC_DEPS)
+-                set(PC_DEPS "${PC_DEPS},")
+-              endif()
+-              # don't duplicate dll-dep if it exists already
+-              set(PC_DEPS "${PC_DEPS} abseil_dll = ${PC_VERSION}")
+-              set(LNK_LIB "${LNK_LIB} -labseil_dll")
+-            endif()
+-          else()
++    if(absl_VERSION)
++      set(PC_VERSION "${absl_VERSION}")
++    else()
++      set(PC_VERSION "head")
++    endif()
++    if(NOT _build_type STREQUAL "dll")
++      set(LNK_LIB "${LNK_LIB} -labsl_${_NAME}")
++    endif()
++    foreach(dep ${ABSL_CC_LIB_DEPS})
++      if(${dep} MATCHES "^absl::(.*)")
++        # for DLL builds many libs are not created, but add
++        # the pkgconfigs nevertheless, pointing to the dll.
++        if(_build_type STREQUAL "dll")
++          # hide this MATCHES in an if-clause so it doesn't overwrite
++          # the CMAKE_MATCH_1 from (${dep} MATCHES "^absl::(.*)")
++          if(NOT PC_DEPS MATCHES "abseil_dll")
+             # Join deps with commas.
+             if(PC_DEPS)
+               set(PC_DEPS "${PC_DEPS},")
+             endif()
+-            set(PC_DEPS "${PC_DEPS} absl_${CMAKE_MATCH_1} = ${PC_VERSION}")
++            # don't duplicate dll-dep if it exists already
++            set(PC_DEPS "${PC_DEPS} abseil_dll = ${PC_VERSION}")
++            set(LNK_LIB "${LNK_LIB} -labseil_dll")
+           endif()
+-        endif()
+-      endforeach()
+-      foreach(cflag ${ABSL_CC_LIB_COPTS})
+-        if(${cflag} MATCHES "^(-Wno|/wd)")
+-          # These flags are needed to suppress warnings that might fire in our headers.
+-          set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")
+-        elseif(${cflag} MATCHES "^(-W|/w[1234eo])")
+-          # Don't impose our warnings on others.
+-        elseif(${cflag} MATCHES "^-m")
+-          # Don't impose CPU instruction requirements on others, as
+-          # the code performs feature detection on runtime.
+         else()
+-          set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")
++          # Join deps with commas.
++          if(PC_DEPS)
++            set(PC_DEPS "${PC_DEPS},")
++          endif()
++          set(PC_DEPS "${PC_DEPS} absl_${CMAKE_MATCH_1} = ${PC_VERSION}")
+         endif()
+-      endforeach()
+-      string(REPLACE ";" " " PC_LINKOPTS "${ABSL_CC_LIB_LINKOPTS}")
+-      FILE(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/lib/pkgconfig/absl_${_NAME}.pc" CONTENT "\
++      endif()
++    endforeach()
++    foreach(cflag ${ABSL_CC_LIB_COPTS})
++      if(${cflag} MATCHES "^(-Wno|/wd)")
++        # These flags are needed to suppress warnings that might fire in our headers.
++        set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")
++      elseif(${cflag} MATCHES "^(-W|/w[1234eo])")
++        # Don't impose our warnings on others.
++      elseif(${cflag} MATCHES "^-m")
++        # Don't impose CPU instruction requirements on others, as
++        # the code performs feature detection on runtime.
++      else()
++        set(PC_CFLAGS "${PC_CFLAGS} ${cflag}")
++      endif()
++    endforeach()
++    string(REPLACE ";" " " PC_LINKOPTS "${ABSL_CC_LIB_LINKOPTS}")
++    FILE(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/lib/pkgconfig/absl_${_NAME}.pc" CONTENT "\
+ prefix=${CMAKE_INSTALL_PREFIX}\n\
+ exec_prefix=\${prefix}\n\
+ libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n\
+@@ -214,9 +213,8 @@ Version: ${PC_VERSION}\n\
+ Requires:${PC_DEPS}\n\
+ Libs: -L\${libdir} ${PC_LINKOPTS} $<$<NOT:$<BOOL:${ABSL_CC_LIB_IS_INTERFACE}>>:${LNK_LIB}>\n\
+ Cflags: -I\${includedir}${PC_CFLAGS}\n")
+-      INSTALL(FILES "${CMAKE_BINARY_DIR}/lib/pkgconfig/absl_${_NAME}.pc"
+-              DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+-    endif()
++    INSTALL(FILES "${CMAKE_BINARY_DIR}/lib/pkgconfig/absl_${_NAME}.pc"
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+   endif()
+ 
+   if(NOT ABSL_CC_LIB_IS_INTERFACE)
+@@ -346,9 +344,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
+     endif()
+   endif()
+ 
+-  # TODO currently we don't install googletest alongside abseil sources, so
+-  # installed abseil can't be tested.
+-  if(NOT ABSL_CC_LIB_TESTONLY AND ABSL_ENABLE_INSTALL)
++  if(ABSL_ENABLE_INSTALL)
+     install(TARGETS ${_NAME} EXPORT ${PROJECT_NAME}Targets
+           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-- 
+2.38.1.windows.1
+

--- a/recipe/patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
+++ b/recipe/patches/0008-CMake-Install-TESTONLY-libraries-and-their-dependenc.patch
@@ -1,8 +1,8 @@
 From 4ed51580e60f87f0cdd2024b407aa6688f65c5ef Mon Sep 17 00:00:00 2001
 From: Derek Mauro <dmauro@google.com>
 Date: Thu, 2 Mar 2023 17:32:02 -0800
-Subject: [PATCH 8/8] CMake: Install TESTONLY libraries and their dependencies
- when they are built
+Subject: [PATCH 08/11] CMake: Install TESTONLY libraries and their
+ dependencies when they are built
 
 https://github.com/abseil/abseil-cpp/issues/1407
 
@@ -136,6 +136,3 @@ index 6d059e7e..f452a676 100644
      install(TARGETS ${_NAME} EXPORT ${PROJECT_NAME}Targets
            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
--- 
-2.38.1.windows.1
-

--- a/recipe/patches/0009-add-some-necessary-source-files-to-ABSL_INTERNAL_TES.patch
+++ b/recipe/patches/0009-add-some-necessary-source-files-to-ABSL_INTERNAL_TES.patch
@@ -1,0 +1,25 @@
+From bfac9193f2b18fb585747df39c27ff94d3fce01d Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Sun, 7 May 2023 18:24:46 +1100
+Subject: [PATCH 09/11] add some necessary source files to
+ ABSL_INTERNAL_TEST_DLL_FILES
+
+---
+ CMake/AbseilDll.cmake | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
+index 1aecd926..26078596 100644
+--- a/CMake/AbseilDll.cmake
++++ b/CMake/AbseilDll.cmake
+@@ -584,6 +584,10 @@ set(ABSL_INTERNAL_TEST_DLL_FILES
+   "hash/hash_testing.h"
+   "log/scoped_mock_log.cc"
+   "log/scoped_mock_log.h"
++  "random/internal/chi_square.cc"
++  "random/internal/chi_square.h"
++  "random/internal/distribution_test_util.cc"
++  "random/internal/distribution_test_util.h"
+   "random/internal/mock_helpers.h"
+   "random/internal/mock_overload_set.h"
+   "random/mocking_bit_gen.h"

--- a/recipe/patches/0010-update-ABSL_CC_TEST_LINKOPTS-when-using-shared-build.patch
+++ b/recipe/patches/0010-update-ABSL_CC_TEST_LINKOPTS-when-using-shared-build.patch
@@ -1,0 +1,24 @@
+From dd5375ee269b6431c029efd1dae91525cb891492 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Sun, 7 May 2023 20:26:19 +1100
+Subject: [PATCH 10/11] update ABSL_CC_TEST_LINKOPTS when using shared build
+
+---
+ CMake/AbseilHelpers.cmake | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMake/AbseilHelpers.cmake b/CMake/AbseilHelpers.cmake
+index f452a676..89f6ba9a 100644
+--- a/CMake/AbseilHelpers.cmake
++++ b/CMake/AbseilHelpers.cmake
+@@ -427,6 +427,10 @@ function(absl_cc_test)
+       DEPS ${ABSL_CC_TEST_DEPS}
+       OUTPUT ABSL_CC_TEST_DEPS
+     )
++    absl_internal_dll_targets(
++      DEPS ${ABSL_CC_TEST_LINKOPTS}
++      OUTPUT ABSL_CC_TEST_LINKOPTS
++    )
+   else()
+     target_compile_definitions(${_NAME}
+       PUBLIC

--- a/recipe/patches/0011-make-CordzHandle-and-relevant-internal-state-use-ABS.patch
+++ b/recipe/patches/0011-make-CordzHandle-and-relevant-internal-state-use-ABS.patch
@@ -1,0 +1,51 @@
+From 783fdeef3098ba22153507abe0f706505c667897 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Mon, 8 May 2023 11:15:46 +1100
+Subject: [PATCH 11/11] make CordzHandle and relevant internal state use
+ ABSL_DLL
+
+---
+ absl/strings/internal/cord_internal.cc | 2 +-
+ absl/strings/internal/cord_internal.h  | 2 +-
+ absl/strings/internal/cordz_handle.h   | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/absl/strings/internal/cord_internal.cc b/absl/strings/internal/cord_internal.cc
+index b6b06cfa..f2842511 100644
+--- a/absl/strings/internal/cord_internal.cc
++++ b/absl/strings/internal/cord_internal.cc
+@@ -33,7 +33,7 @@ ABSL_CONST_INIT std::atomic<bool> cord_ring_buffer_enabled(
+     kCordEnableRingBufferDefault);
+ ABSL_CONST_INIT std::atomic<bool> shallow_subcords_enabled(
+     kCordShallowSubcordsDefault);
+-ABSL_CONST_INIT std::atomic<bool> cord_btree_exhaustive_validation(false);
++ABSL_CONST_INIT ABSL_DLL std::atomic<bool> cord_btree_exhaustive_validation(false);
+ 
+ void LogFatalNodeType(CordRep* rep) {
+   ABSL_INTERNAL_LOG(FATAL, absl::StrCat("Unexpected node type: ",
+diff --git a/absl/strings/internal/cord_internal.h b/absl/strings/internal/cord_internal.h
+index 63a81f4f..796d4de9 100644
+--- a/absl/strings/internal/cord_internal.h
++++ b/absl/strings/internal/cord_internal.h
+@@ -73,7 +73,7 @@ extern std::atomic<bool> shallow_subcords_enabled;
+ // in debug assertions, and code that calls `IsValid()` explicitly. By default,
+ // assertions should be relatively cheap and AssertValid() can easily lead to
+ // O(n^2) complexity as recursive / full tree validation is O(n).
+-extern std::atomic<bool> cord_btree_exhaustive_validation;
++ABSL_DLL extern std::atomic<bool> cord_btree_exhaustive_validation;
+ 
+ inline void enable_cord_ring_buffer(bool enable) {
+   cord_ring_buffer_enabled.store(enable, std::memory_order_relaxed);
+diff --git a/absl/strings/internal/cordz_handle.h b/absl/strings/internal/cordz_handle.h
+index 3c800b43..c4ac7cb8 100644
+--- a/absl/strings/internal/cordz_handle.h
++++ b/absl/strings/internal/cordz_handle.h
+@@ -34,7 +34,7 @@ namespace cord_internal {
+ // has gained visibility into a CordzInfo object, that CordzInfo object will not
+ // be deleted prematurely. This allows the profiler to inspect all CordzInfo
+ // objects that are alive without needing to hold a global lock.
+-class CordzHandle {
++class ABSL_DLL CordzHandle {
+  public:
+   CordzHandle() : CordzHandle(false) {}
+ 


### PR DESCRIPTION
Protobuf [wants](https://github.com/protocolbuffers/protobuf/blob/v22.3/cmake/abseil-cpp.cmake#L82-L84) `absl::scoped_mock_log` to build (with tests, which I'd like to not disable), but abseil declares that as a test-only dep which isn't built by default.

Let's build them to unblock https://github.com/conda-forge/libprotobuf-feedstock/pull/144

Closes #57
Closes #55
Closes #48