### PR TITLE
overwrite CMake metadata for libabseil-tests

### DIFF
--- a/recipe/cmake_test/CMakeLists.txt
+++ b/recipe/cmake_test/CMakeLists.txt
@@ -4,3 +4,9 @@ find_package(absl REQUIRED CONFIG)
 
 add_executable(flags_example flags_example.cpp)
 target_link_libraries(flags_example absl::flags absl::strings)
+
+if(DEFINED ENV{TRY_TEST_TARGET})
+    # check if we can find a test target (i.e. that the cmake metadata from
+    # vanilla libabseil has been updated correctly for libabseil-tests)
+    target_link_libraries(flags_example absl::scoped_mock_log)
+endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ source:
     - patches/0011-make-CordzHandle-and-relevant-internal-state-use-ABS.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   # default behaviour is shared; however note that upstream does not support
@@ -134,6 +134,10 @@ outputs:
     script: build-abseil.bat  # [win]
     build:
       string: cxx{{ cxx_standard }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      always_include_files:
+        # Must overwrite cmake metadata from libabseil
+        - lib/cmake/absl/          # [unix]
+        - Library/lib/cmake/absl/  # [win]
 
     requirements:
       build:
@@ -153,7 +157,12 @@ outputs:
 
     test:
       requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
         - pkg-config
+      files:
+        - cmake_test/
       commands:
         # windows-only (almost-)all-in-one DLL + import library
         - if not exist %LIBRARY_BIN%\\abseil_test_dll.dll exit 1      # [win]
@@ -173,6 +182,18 @@ outputs:
         # pkg-config abseil_test_dll
         - pkg-config --print-errors --exact-version "{{ v_major }}" abseil_test_dll  # [win]
 
+        # CMake integration
+        - cd cmake_test
+        - export CMAKE_ARGS="$CMAKE_ARGS -GNinja -DCMAKE_BUILD_TYPE=Release"  # [unix]
+        - set "CMAKE_ARGS=%CMAKE_ARGS% -GNinja -DCMAKE_BUILD_TYPE=Release"    # [win]
+        - cmake $CMAKE_ARGS  -DCMAKE_CXX_STANDARD={{ cxx_standard }} .        # [unix]
+        - cmake %CMAKE_ARGS% -DCMAKE_CXX_STANDARD={{ cxx_standard }} .        # [win]
+        # enable search for test target
+        - export TRY_TEST_TARGET=1  # [unix]
+        - set TRY_TEST_TARGET=1     # [win]
+        - cmake --build .
+        - ./flags_example    # [unix]
+        - flags_example.exe  # [win]
 about:
   home: https://github.com/abseil/abseil-cpp
   license: Apache-2.0


### PR DESCRIPTION
Follow-up from #58 because it's not yet usable in https://github.com/conda-forge/libprotobuf-feedstock/pull/144