### PR TITLE
loosen run-export to major version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ source:
     - patches/0011-make-CordzHandle-and-relevant-internal-state-use-ABS.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   # default behaviour is shared; however note that upstream does not support
@@ -60,7 +60,9 @@ outputs:
     build:
       string: cxx{{ cxx_standard }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       run_exports:
-        - libabseil ={{ version }}=cxx{{ cxx_standard }}*
+        - {{ pin_subpackage("libabseil", max_pin="x") }}
+        # also pin on ABI variant
+        - libabseil =*=cxx{{ cxx_standard }}*
 
     requirements:
       build:


### PR DESCRIPTION
The global pinning only sets the major versions (e.g. "20230125"), and now that #58 included a bump to 20230125.2, we get conflicts for environments where certain packages have been built against abseil major.0 & major.2.

The ABI shouldn't change between minor versions, so loosen the pin.