### PR TITLE
Require MacOS >=10.13

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
 c_compiler:

--- a/recipe/build-abseil.sh
+++ b/recipe/build-abseil.sh
@@ -13,12 +13,6 @@ fi
 if [[ "$PKG_NAME" == "libabseil-tests" ]]; then
     CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_TESTING=ON -DABSL_BUILD_TESTING=ON"
     CMAKE_ARGS="${CMAKE_ARGS} -DABSL_USE_EXTERNAL_GOOGLETEST=ON -DABSL_FIND_GOOGLETEST=ON"
-    if [[ "${target_platform}" == osx-* ]]; then
-        # test targets require C11's aligned_alloc, which doesn't compile even
-        # with a newer MACOSX_SDK_VERSION; need to bump target version too
-        CMAKE_ARGS="$(echo $CMAKE_ARGS | sed 's/-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 //g')"
-        CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
-    fi
 fi
 
 cmake -G Ninja \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,7 @@
+# abseil now only support MacOS >=10.13, see
+# https://github.com/abseil/abseil-cpp#support and
+# https://github.com/abseil/abseil-cpp/issues/1513
 MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "10.13"                # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.13"                # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - patches/0004-default-dll-import-for-windows.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   # default behaviour is shared; however note that upstream does not support
@@ -63,6 +63,7 @@ outputs:
         - libabseil-static ={{ version }}=cxx{{ cxx_standard }}*
         # make sure we don't co-install with old version of old package name
         - abseil-cpp ={{ version }}
+        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
     test:
       requires:
@@ -143,8 +144,7 @@ outputs:
         - gtest
         - {{ pin_subpackage("libabseil", exact=True) }}
       run_constrained:
-        # only for libabseil-tests, see build-abseil.sh
-        - __osx >=10.13  # [osx and x86_64]
+        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
     test:
       requires:


### PR DESCRIPTION
Running against older MacOS [fails](https://github.com/abseil/abseil-cpp/issues/1513). Abseil's support [policy](https://github.com/abseil/abseil-cpp#support) also requires 10.13 since this May (even though the build doesn't error, it fails for dependent projects).