### PR TITLE
upgrade `__osx` constraint to run-export

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     - patches/0004-default-dll-import-for-windows.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   # default behaviour is shared; however note that upstream does not support
@@ -52,6 +52,10 @@ outputs:
         - {{ pin_subpackage("libabseil", max_pin="x") }}
         # also pin on ABI variant
         - libabseil =*=cxx{{ cxx_standard }}*
+        # abseil needs the 10.13 headers even just to be `# include`d;
+        # ensure that all dependent packages reflect that to
+        # avoid the solver getting stuck in no-man's-land.
+        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
     requirements:
       build:
@@ -63,7 +67,6 @@ outputs:
         - libabseil-static ={{ version }}=cxx{{ cxx_standard }}*
         # make sure we don't co-install with old version of old package name
         - abseil-cpp ={{ version }}
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
     test:
       requires:
@@ -143,8 +146,6 @@ outputs:
       run:
         - gtest
         - {{ pin_subpackage("libabseil", exact=True) }}
-      run_constrained:
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
     test:
       requires:


### PR DESCRIPTION
For unblocking https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4814