### PR TITLE
avoid using C++20 stdlib-features when compiling with higher C++-standard

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,11 @@ source:
     # Helps downstream packages import the dll without an extra define
     # https://github.com/conda-forge/abseil-cpp-feedstock/issues/43#issuecomment-1242969515
     - patches/0004-default-dll-import-for-windows.patch
+    # avoid that compilation in C++20 mode changes the ABI vs. C++17
+    - patches/0005-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   # default behaviour is shared; however note that upstream does not support

--- a/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
+++ b/recipe/patches/0001-patch-out-the-build-issue-on-clang4-osx.patch
@@ -1,14 +1,14 @@
-From 957710d9a3694a4d128fb5b29cbbc606409d9919 Mon Sep 17 00:00:00 2001
+From beb40c9c8a4e2f69a33a78c9c93bf7f58871c96f Mon Sep 17 00:00:00 2001
 From: Francesco Biscani <bluescarni@gmail.com>
 Date: Sat, 21 Sep 2019 15:05:46 +0200
-Subject: [PATCH 1/4] patch out the build issue on clang4 osx
+Subject: [PATCH 1/5] patch out the build issue on clang4 osx
 
 ---
  absl/time/internal/cctz/include/cctz/civil_time_detail.h | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/absl/time/internal/cctz/include/cctz/civil_time_detail.h b/absl/time/internal/cctz/include/cctz/civil_time_detail.h
-index a5b084e6..0a9a4389 100644
+index 2b0aed56..a9ec715d 100644
 --- a/absl/time/internal/cctz/include/cctz/civil_time_detail.h
 +++ b/absl/time/internal/cctz/include/cctz/civil_time_detail.h
 @@ -15,6 +15,10 @@

--- a/recipe/patches/0002-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
+++ b/recipe/patches/0002-remove-ignore-4221-from-ABSL_MSVC_LINKOPTS.patch
@@ -1,7 +1,7 @@
-From 1873cccd7401c41232b17806bb3dc61c63c98f74 Mon Sep 17 00:00:00 2001
+From b3cb423fa77bf132eff2f3ca2a2c471c2d606219 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Thu, 30 Jul 2020 13:01:32 +0200
-Subject: [PATCH 2/4] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
+Subject: [PATCH 2/5] remove "-ignore:4221" from ABSL_MSVC_LINKOPTS
 
 see also https://github.com/microsoft/vcpkg/issues/13945
 ---

--- a/recipe/patches/0003-add-missing-osx-workaround.patch
+++ b/recipe/patches/0003-add-missing-osx-workaround.patch
@@ -1,7 +1,7 @@
-From 32516fe195fe3c411d204cf732d74436ad5c1108 Mon Sep 17 00:00:00 2001
+From f3ebba74fda755fa7002f8c6ec64b77cb3e7e38e Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Fri, 1 Jul 2022 13:37:17 +0200
-Subject: [PATCH 3/4] add missing osx workaround
+Subject: [PATCH 3/5] add missing osx workaround
 
 ---
  absl/debugging/internal/examine_stack.cc | 4 ++++

--- a/recipe/patches/0004-default-dll-import-for-windows.patch
+++ b/recipe/patches/0004-default-dll-import-for-windows.patch
@@ -1,17 +1,17 @@
-From 9f00f62c14645d7f35eae659a4f015205379fd22 Mon Sep 17 00:00:00 2001
+From a023e403af16c99eb25ba5c476bb19edc0df6d6f Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 11 Sep 2022 10:32:19 -0400
-Subject: [PATCH 4/4] default dll import for windows
+Subject: [PATCH 4/5] default dll import for windows
 
 ---
  absl/base/config.h | 5 ++---
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/absl/base/config.h b/absl/base/config.h
-index 1de79930..7385eb84 100644
+index 762bb7f7..6ba9361f 100644
 --- a/absl/base/config.h
 +++ b/absl/base/config.h
-@@ -695,10 +695,9 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+@@ -743,10 +743,9 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
  #if defined(_MSC_VER)
  #if defined(ABSL_BUILD_DLL)
  #define ABSL_DLL __declspec(dllexport)

--- a/recipe/patches/0005-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
+++ b/recipe/patches/0005-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
@@ -1,0 +1,23 @@
+From c27c0ea092f6a67160f5398a1a85e95969ed153f Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 7 Feb 2024 17:07:42 +0100
+Subject: [PATCH 5/5] don't use C++20 stdlib-features which change ABI compared
+ to C++17 baseline
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 194f8708..1cf84398 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,7 +234,7 @@ if(ABSL_ENABLE_INSTALL)
+     foreach(FEATURE "ORDERING")
+       string(REPLACE
+       "#define ABSL_OPTION_USE_STD_${FEATURE} 2"
+-      "#define ABSL_OPTION_USE_STD_${FEATURE} 1"
++      "#define ABSL_OPTION_USE_STD_${FEATURE} 0"
+       ABSL_INTERNAL_OPTIONS_H_PINNED
+       "${ABSL_INTERNAL_OPTIONS_H_CONTENTS}")
+       set(ABSL_INTERNAL_OPTIONS_H_CONTENTS "${ABSL_INTERNAL_OPTIONS_H_PINNED}")


### PR DESCRIPTION
Mitigation for ABI-sensitive option that occurred in the last abseil version; avoid that projects compiling against our abseil in C++20 mode break the (C++17) ABI that we're using here.

For more context see the relevant [section](https://github.com/abseil/abseil-cpp/blob/20240116.0/CMakeLists.txt#L232-L254) of upstream CMakeLists.txt, resp. the discussion in #45.