### PR TITLE
backport patch for nvcc workaround

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,9 +37,11 @@ source:
     - patches/0002-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
     # workaround for https://github.com/abseil/abseil-cpp/issues/1624
     - patches/0003-unconditionally-export-Mutex-Destructor.patch
+    # backport https://github.com/abseil/abseil-cpp/commit/cfde5f74e276049727f9556f13473a59fe77d9eb
+    - patches/0004-Workaround-for-NVIDIA-C-compiler-being-unable-to-par.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   # default behaviour is shared; however note that upstream does not support

--- a/recipe/patches/0001-default-dll-import-for-windows.patch
+++ b/recipe/patches/0001-default-dll-import-for-windows.patch
@@ -1,14 +1,14 @@
-From 3b5410d4e955b5b6a6c90abd3a6f02c045a43326 Mon Sep 17 00:00:00 2001
+From 681f595247ce7b1675e624f4d57959bfa70b11c0 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sun, 11 Sep 2022 10:32:19 -0400
-Subject: [PATCH 1/3] default dll import for windows
+Subject: [PATCH 1/4] default dll import for windows
 
 ---
  absl/base/config.h | 5 ++---
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/absl/base/config.h b/absl/base/config.h
-index 762bb7f7..6ba9361f 100644
+index c9165acd..b0d5650c 100644
 --- a/absl/base/config.h
 +++ b/absl/base/config.h
 @@ -743,10 +743,9 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||

--- a/recipe/patches/0002-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
+++ b/recipe/patches/0002-don-t-use-C-20-stdlib-features-which-change-ABI-comp.patch
@@ -1,7 +1,7 @@
-From 9981632d5efba83f55ed357650b3a88ec6d7acaf Mon Sep 17 00:00:00 2001
+From 925064703e6e48f36920c9f65a45efb4981ecb49 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 7 Feb 2024 17:07:42 +0100
-Subject: [PATCH 2/3] don't use C++20 stdlib-features which change ABI compared
+Subject: [PATCH 2/4] don't use C++20 stdlib-features which change ABI compared
  to C++17 baseline
 
 ---

--- a/recipe/patches/0003-unconditionally-export-Mutex-Destructor.patch
+++ b/recipe/patches/0003-unconditionally-export-Mutex-Destructor.patch
@@ -1,7 +1,7 @@
-From 647571e5e81f28e39fec55bf41ace4114a96d76b Mon Sep 17 00:00:00 2001
+From f86ffcfba84ec681a70249a61be3b7d2c7f32fa4 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Tue, 13 Feb 2024 08:43:06 +0100
-Subject: [PATCH 3/3] unconditionally export Mutex Destructor
+Subject: [PATCH 3/4] unconditionally export Mutex Destructor
 
 ---
  absl/synchronization/mutex.cc | 2 --

--- a/recipe/patches/0004-Workaround-for-NVIDIA-C-compiler-being-unable-to-par.patch
+++ b/recipe/patches/0004-Workaround-for-NVIDIA-C-compiler-being-unable-to-par.patch
@@ -1,0 +1,47 @@
+From 69220b657f2ac271e5179bc29d33e73c10720436 Mon Sep 17 00:00:00 2001
+From: Abseil Team <absl-team@google.com>
+Date: Wed, 28 Feb 2024 09:40:08 -0800
+Subject: [PATCH 4/4] Workaround for NVIDIA C++ compiler being unable to parse
+ variadic expansions in range of range-based for loop
+
+Fixes: #1629
+PiperOrigin-RevId: 611131201
+Change-Id: I787731e00207b544ee16055e6e0d323a5094a433
+---
+ absl/strings/str_cat.h | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/absl/strings/str_cat.h b/absl/strings/str_cat.h
+index ea2c4dca..1b52a36f 100644
+--- a/absl/strings/str_cat.h
++++ b/absl/strings/str_cat.h
+@@ -601,18 +601,17 @@ StrAppend(absl::Nonnull<String*> str, T... args) {
+   ptrdiff_t n;   // The length of the current argument
+   typename String::pointer pos = &(*str)[old_size];
+   using SomeTrivialEmptyType = std::false_type;
+-  // Ugly code due to the lack of C++14 fold expression makes us.
+-  const SomeTrivialEmptyType dummy1;
+-  for (const SomeTrivialEmptyType& dummy2 :
+-       {(/* Comma expressions are poor man's C++17 fold expression for C++14 */
+-         (void)(n = lengths[i]),
+-         (void)(n < 0 ? (void)(*pos++ = '-'), (n = ~n) : 0),
+-         (void)absl::numbers_internal::FastIntToBufferBackward(
+-             absl::numbers_internal::UnsignedAbsoluteValue(std::move(args)),
+-             pos += n, static_cast<uint32_t>(n)),
+-         (void)++i, dummy1)...}) {
+-    (void)dummy2;  // Remove & migrate to fold expressions in C++17
+-  }
++  const SomeTrivialEmptyType dummy;
++  // Ugly code due to the lack of C++17 fold expressions
++  const SomeTrivialEmptyType dummies[] = {
++      (/* Comma expressions are poor man's C++17 fold expression for C++14 */
++       (void)(n = lengths[i]),
++       (void)(n < 0 ? (void)(*pos++ = '-'), (n = ~n) : 0),
++       (void)absl::numbers_internal::FastIntToBufferBackward(
++           absl::numbers_internal::UnsignedAbsoluteValue(std::move(args)),
++           pos += n, static_cast<uint32_t>(n)),
++       (void)++i, dummy)...};
++  (void)dummies;  // Remove & migrate to fold expressions in C++17
+ }
+ 
+ // Helper function for the future StrCat default floating-point format, %.6g


### PR DESCRIPTION
Backport fix for https://github.com/abseil/abseil-cpp/issues/1629; needed for https://github.com/conda-forge/tensorflow-feedstock/pull/372 etc.